### PR TITLE
Add initial personal blog template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-sitemap"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Personal Blog Template
+
+This repository contains a Jekyll site powered by the
+[minimal-mistakes](https://github.com/mmistakes/minimal-mistakes) theme.
+It is configured for hosting on GitHub Pages and provides a simple starting
+point for personal blog posts.
+
+## Running locally
+
+1. Install [Ruby](https://www.ruby-lang.org/en/) and
+   [Bundler](https://bundler.io/).
+2. Install dependencies:
+   ```bash
+   bundle install
+   ```
+3. Serve the site locally:
+   ```bash
+   bundle exec jekyll serve
+   ```
+4. Visit `http://localhost:4000` in your browser.
+
+## Deployment
+
+The repository includes a GitHub Actions workflow that builds and deploys
+the site automatically when changes are pushed to the `gh-pages` branch.

--- a/_config.yml
+++ b/_config.yml
@@ -19,16 +19,22 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Paul Breuler
-description: >- # this means to ignore newlines until "baseurl:"
-Automated Lifecycle Management (ALM) for the Microsoft Power Platform expert | Educator | Software Engineer -- Full-stack & .Net 
+description: >-
+  Automated Lifecycle Management (ALM) for the Microsoft Power Platform expert,
+  educator, and full‑stack software engineer.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://paulbreuler.github.io/" # the base hostname & protocol for your site, e.g. http://example.com
-github_username:  paulbreuler
+url: "https://paulbreuler.github.io" # the base hostname & protocol for your site
+github_username: paulbreuler
+
+# Personalization
+minimal_mistakes_skin: "air"
+paginate: 5
 
 # Build settings
 theme: minimal-mistakes-jekyll
 plugins:
   - jekyll-feed
+  - jekyll-sitemap
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,4 @@
+paulbreuler:
+  name: "Paul Breuler"
+  bio: "Automated Lifecycle Management specialist, educator, and software engineer."
+  location: "USA"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,5 @@
+main:
+  - title: "Home"
+    url: /
+  - title: "About"
+    url: /about/

--- a/_posts/2022-08-21-welcome-to-jekyll.markdown
+++ b/_posts/2022-08-21-welcome-to-jekyll.markdown
@@ -1,5 +1,6 @@
 ---
 layout: post
+author: paulbreuler
 title:  "Welcome to Jekyll!"
 date:   2022-08-21 00:58:29 +0000
 categories: jekyll update

--- a/about.markdown
+++ b/about.markdown
@@ -4,15 +4,9 @@ title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+Welcome to my personal site. Here you'll find blog posts and notes about
+Automated Lifecycle Management for the Microsoft Power Platform, development
+tips, and other things I'm working on.
 
-You can find the source code for Minima at GitHub:
-[jekyll][jekyll-organization] /
-[minima](https://github.com/jekyll/minima)
-
-You can find the source code for Jekyll at GitHub:
-[jekyll][jekyll-organization] /
-[jekyll](https://github.com/jekyll/jekyll)
-
-
-[jekyll-organization]: https://github.com/jekyll
+Feel free to browse the posts and reach out via GitHub if you'd like to
+connect or have questions.

--- a/index.markdown
+++ b/index.markdown
@@ -3,4 +3,5 @@
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 
 layout: home
+author_profile: true
 ---


### PR DESCRIPTION
## Summary
- personalize `_config.yml` with minimal-mistakes settings
- add author and navigation data
- show author profile on home page
- update about page content
- include README with usage instructions
- add jekyll-sitemap plugin

## Testing
- `bundle install` *(fails: could not fetch specs)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*